### PR TITLE
[W4.11e][F11-3]Jeffery Kwoh Add Testcases for Utils.isAnyNull & bugfix

### DIFF
--- a/src/seedu/addressbook/common/Utils.java
+++ b/src/seedu/addressbook/common/Utils.java
@@ -13,6 +13,10 @@ public class Utils {
      * Returns true if any of the given items are null.
      */
     public static boolean isAnyNull(Object... items) {
+        if (items == null) {
+            return true;
+        }
+
         for (Object item : items) {
             if (item == null) {
                 return true;

--- a/test/java/seedu/addressbook/common/UtilsTest.java
+++ b/test/java/seedu/addressbook/common/UtilsTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.Test;
 
@@ -42,5 +41,48 @@ public class UtilsTest {
 
     private void assertNotUnique(Object... objects) {
         assertFalse(Utils.elementsAreUnique(Arrays.asList(objects)));
+    }
+
+    @Test
+    /**
+     *
+     */
+    public void elementsAreNull() throws Exception {
+        // empty list
+        assertNoNull();
+
+        // single object no null
+        assertNoNull("");
+        assertNoNull("abc");
+        assertNoNull(1);
+        assertNoNull(true);
+        assertNoNull(false);
+
+        // all objects without null
+        assertNoNull("abc", "ab", "a");
+        assertNoNull(1, 2);
+        assertNoNull("abc", "abc");
+        assertNoNull("abc", "", "abc", "ABC");
+        assertNoNull("", "abc", "a", "abc");
+        assertNoNull(1, Integer.valueOf(1));
+
+        // some objects with null
+        assertContainsNull(null, 1, Integer.valueOf(1));
+        assertContainsNull(null, null);
+        assertContainsNull(null, "a", "b", null);
+
+        // null with Object typecast
+        assertContainsNull((Object) null);
+
+        // null without typecast
+        assertContainsNull(null);
+    }
+
+    private void assertContainsNull(Object... objects) {
+        assertTrue(Utils.isAnyNull(objects));
+    }
+
+    private void assertNoNull(Object... objects) {
+        assertFalse(Utils.isAnyNull(objects));
     }
 }


### PR DESCRIPTION
Add testcases for Utils.isAnyNull

Also fix bug where null is passed into the argument and instead of returning true as intuitively expected, a NullPointerException is thrown.